### PR TITLE
Better contrast in link hover state on examples page

### DIFF
--- a/site/styles/examples.css
+++ b/site/styles/examples.css
@@ -192,7 +192,7 @@ body {
 	cursor: pointer;
 }
 .example-grid-element-title:hover {
-	color: #c9fbe9;
+	color: #117755;
 }
 
 .example-grid-element-open-in-editor-link {


### PR DESCRIPTION
On the examples page of the website, the hover state for the title makes it hard to read, and unreadable depending on where the link is relative to the background gradient:

![Hover state on links lacks contrast](https://user-images.githubusercontent.com/1209371/31592209-7f4bf456-b1db-11e7-9b2b-d2745d999df1.PNG)

This PR changes the hover text color to `#117755`, which is a darker shade of green:

![wick-link-better](https://user-images.githubusercontent.com/1209371/31592210-7f67814e-b1db-11e7-99f5-3462fc5ad569.PNG)
